### PR TITLE
rename xlist to arg_list

### DIFF
--- a/jinja2heat-template.py
+++ b/jinja2heat-template.py
@@ -6,7 +6,7 @@ import sys
 def jinja2_to_heat(template_file, output_file, arg_list):
     f = file(template_file)
     compiled_template = jinja2.Template(f.read())
-    rendered_template = compiled_template.render({"xlist": arg_list})
+    rendered_template = compiled_template.render({"arg_list": arg_list})
     tmp_file = file(output_file, mode="w")
     tmp_file.write(rendered_template)
     tmp_file.close

--- a/router.hot
+++ b/router.hot
@@ -1,32 +1,36 @@
 heat_template_version: 2013-05-23
 
 description:
-  create some net and router
+  create some net and router,for test how many router can be create in openstack
 
 parameters:
+  ext_net:
+    type: string
+    description: external net for router
+    defualt: ext_net
 
 resources:
-{% for x in xlist %}
-  {{ x }}_private_net:
+{% for arg in arg_list %}
+  {{ arg }}_private_net:
     type: OS::Neutron::Net
     properties:
       name: heat1_net
 
-  {{ x }}_private_subnet:
+  {{ arg }}_private_subnet:
     type: OS::Neutron::Subnet
     properties:
-      network_id: { get_resource: {{ x }}_private_net }
-      cidr: 11.0.0.0/8
+      network_id: { get_resource: {{ arg }}_private_net }
+      cidr: 11.0.0.0/24
 
-  {{ x }}_router:
+  {{ arg }}_router:
     type: OS::Neutron::Router
     properties:
       external_gateway_info:
-        network: 5048-ext-net 
+        network: { get_param: ext_net}
 
-  {{ x }}_router_interface:
+  {{ arg }}_router_interface:
     type: OS::Neutron::RouterInterface
     properties:
-      router_id: { get_resource: {{ x }}_router }
-      subnet_id: { get_resource: {{ x }}_private_subnet }
+      router_id: { get_resource: {{ arg }}_router }
+      subnet_id: { get_resource: {{ arg }}_private_subnet }
 {% endfor %}

--- a/server_with_volume.yaml
+++ b/server_with_volume.yaml
@@ -1,0 +1,65 @@
+heat_template_version: 2015-04-30
+
+description: >
+  A template showing how to create a cinder volume and attach
+  it to a nova instance. The template uses only Heat OpenStack native
+  resource types.
+
+parameters:
+  image_id:
+    type: string
+    description: ID of the image to use for the instance to be created.
+  instance_type:
+    type: string
+    description: Type of the instance to be created.
+    default: m1.small
+  availability_zone:
+    type: string
+    description: The Availability Zone to launch the instance.
+    default: nova
+  volume_size:
+    type: number
+    description: Size of the volume to be created.
+    default: 1
+    constraints:
+      - range: { min: 1, max: 1024 }
+        description: must be between 1 and 1024 Gb.
+
+resources:
+  private_net:
+    type: OS::Neutron::Net
+  private_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: private_net }
+      cidr: 11.0.0.0/16
+  x_port:
+    type: OS::Neutron::Port
+    properties:
+      network_id: { get_resource: private_net }
+      fixed_ips:
+        - subnet_id: { get_resource: private_subnet }
+  nova_instance:
+    type: OS::Nova::Server
+    properties:
+      availability_zone: { get_param: availability_zone }
+      metadata:
+              admin_pass: aaaaaa
+      image: { get_param: image_id }
+      flavor: { get_param: instance_type }
+      networks:
+        - port: { get_resource: x_port }
+{% for arg in arg_list %}
+  cinder_volume_{{ arg }}:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: volume_size }
+      availability_zone: { get_param: availability_zone }
+      volume_type: CEPHx
+  cinder_volume_attachment_{{ arg }}:
+    type: OS::Cinder::VolumeAttachment
+    properties:
+      volume_id: { get_resource: cinder_volume_{{ arg }} }
+      instance_uuid: { get_resource: nova_instance }
+{% endfor %}
+


### PR DESCRIPTION
将router.hot模板中的xlist重命名为arg_list
增加server_with_volume.yaml模板，用于测试一台云主机上挂载多个云硬盘的测试